### PR TITLE
Added a 180s wait for AAD role propogation

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "azurerm" {
 }
 
 locals {
-  unique_name_stub = substr(module.naming.unique-seed, 0, 5)
+  unique_name_stub = substr(module.naming.unique-seed, 0, 3)
 }
 
 module "naming" {
@@ -33,12 +33,12 @@ resource "azurerm_subnet" "subnet" {
 module "terraform-azurerm-storage" {
   source                               = "../../"
   resource_group_name                  = azurerm_resource_group.test_group.name
-  storage_account_name                 = "testsafull"
+  storage_account_name                 = "testsafull${local.unique_name_stub}"
   storage_account_tier                 = "Standard"
   storage_account_replication_type     = "LRS"
   allowed_ip_ranges                    = [data.external.test_client_ip.result.ip]
   permitted_virtual_network_subnet_ids = [azurerm_subnet.subnet.id]
   bypass_internal_network_rules        = true
-  #enable_data_lake_filesystem          = true
-  #data_lake_filesystem_name            = module.naming.data_lake_file_system.name_unique
+  enable_data_lake_filesystem          = true
+  data_lake_filesystem_name            = module.naming.storage_data_lake_gen2_filesystem.name_unique
 }

--- a/main.tf
+++ b/main.tf
@@ -39,9 +39,18 @@ resource "azurerm_role_assignment" "role_assignment" {
   principal_id         = data.azurerm_client_config.user.object_id
 }
 
+resource "time_sleep" "role_assignment_wait" {
+  depends_on = [
+    azurerm_role_assignment.role_assignment
+  ]
+
+  create_duration = "90s"
+  count           = var.enable_data_lake_filesystem ? 1 : 0 
+}
+
 resource "azurerm_storage_data_lake_gen2_filesystem" "data_lake_gen2_filesystem" {
   name               = length(var.data_lake_filesystem_name) == 0 ? module.naming.storage_data_lake_gen2_filesystem.name_unique : var.data_lake_filesystem_name
   storage_account_id = azurerm_storage_account.storage_account.id
-  depends_on         = [azurerm_role_assignment.role_assignment]
+  depends_on         = [time_sleep.role_assignment_wait]
   count              = var.enable_data_lake_filesystem ? 1 : 0
 }

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "time_sleep" "role_assignment_wait" {
     azurerm_role_assignment.role_assignment
   ]
 
-  create_duration = "90s"
+  create_duration = "180s"
   count           = var.enable_data_lake_filesystem ? 1 : 0 
 }
 


### PR DESCRIPTION
90 second wait introduced before created the ADLS Gen2 filename space. This allows for the AAD role to propogate fully to allow for successful filename space creation.